### PR TITLE
Added support for an option to include the name of the recipe in the macro

### DIFF
--- a/app/components/macros.html
+++ b/app/components/macros.html
@@ -6,6 +6,11 @@
         <input type="checkbox" ng-model="options.includeMacroLock"/>{{ 'MACRO_INCLUDE_LOCK' | translate }}
       </label>
     </div>
+    <div class="controls">
+      <label class="checkbox">
+        <input type="checkbox" ng-model="options.includeMacroTitle"/>{{ 'MACRO_INCLUDE_TITLE' | translate }}
+      </label>
+    </div>
   </div>
 </form>
 <div ng-repeat="macro in macroList track by $index">

--- a/app/js/components/macros.js
+++ b/app/js/components/macros.js
@@ -14,7 +14,8 @@
       scope: {
         sequence: '=',
         cls: '=',
-        options: '='
+        options: '=',
+        recipe: '=',
       },
       controller: controller
     }
@@ -27,6 +28,7 @@
     $scope.$watchCollection('sequence', update);
     $scope.$watch('cls', update);
     $scope.$watchCollection('options', update);
+    $scope.$watch('recipe', update);
 
     update();
 
@@ -38,7 +40,7 @@
       }
 
       var sequenceLines = buildSequenceLines($scope.options, $scope.sequence, extractBuffs());
-      $scope.macroList = buildMacroList($scope.options, sequenceLines);
+      $scope.macroList = buildMacroList($scope.options, $scope.recipe, sequenceLines);
     }
 
     function extractBuffs() {
@@ -94,17 +96,23 @@
       return lines;
     }
 
-    function buildMacroList(options, lines) {
+    function buildMacroList(options, recipe, lines) {
       var macroList = [];
 
       var macroString = '';
       var macroLineCount = 0;
       var macroTime = 0;
       var macroIndex = 1;
+      var macroTitle = recipe;      
 
       if (options.includeMacroLock) {
         macroString += '/macrolock\n';
           macroLineCount++;
+      }
+
+      if (options.includeMacroTitle) {
+        macroString += '/echo Macro for ' + macroTitle + ' started' + '\n';
+        macroLineCount++;
       }
 
       for (var j = 0; j < lines.length; j++) {

--- a/app/locale/ar.json
+++ b/app/locale/ar.json
@@ -65,6 +65,7 @@
     "MACRO_CROSS_ACTION_SETUP": "تمثيل عابر الصف يفعل الماكرو",
     "MACRO_INCLUDE_CLASS": "قم بتضمين تصرفات الفئة الحالية في ماكرو تنشيط التنشيط عبر الفئات",
     "MACRO_INCLUDE_LOCK": "قم بتضمين قفل الماكرو في بداية كل ماكرو",
+    "MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
   
     "INITIAL_GUESS": "التخمين الأولي",
     "WORKING_IN_PROGRESS": "يعمل...",
@@ -128,6 +129,7 @@
     "CROSS_CLASS_INFO": "",
     "CURRENT_CLASS_INFO": "ما إذا كنت تريد إنشاء ماكرو منفصل ينشط الإجراءات المتقاطعة الضرورية.",
     "MACRO_LOCK_INFO": "ما إذا كنت تريد تضمين أمر قفل الماكرو في بداية كل ماكرو.",
+    "MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
     "SPECIFY_SEED": "تحديد البذور",
     "SEED_INFO": "اضبط هذا على قيمة محددة لإعادة إنتاج نفس الشروط في محاكاة مونت كارلو.",
     "SPECIFY_SEED_INFO": "تمكن من تجاوز البذور العشوائية المستخدمة لمحاكاة مونت كارلو.",

--- a/app/locale/cn.json
+++ b/app/locale/cn.json
@@ -134,6 +134,7 @@
   "MACRO_CROSS_ACTION_SETUP": "额外技能激活宏",
   "MACRO_INCLUDE_CLASS": "生成“额外技能激活宏”时包含当前职业的“共通技能”",
   "MACRO_INCLUDE_LOCK": "在每个宏指令的开头包含“锁定宏指令（/macrolock）”，以保护该宏在执行完毕前不会被其他操作打断。",
+  "MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
 
   "INITIAL_GUESS": "初步猜测",
   "WORKING_IN_PROGRESS": "运行中...",
@@ -197,6 +198,7 @@
   "CROSS_CLASS_INFO": "生成一个单独的宏指令来激活必要的“额外技能”。",
   "CURRENT_CLASS_INFO": "生成“额外技能激活宏”时包括当前职业的“共通技能”",
   "MACRO_LOCK_INFO": "在每个宏指令的开头包含“锁定宏指令（/macrolock）”，以保护该宏指令在执行完毕前不会被其他操作打断。",
+  "MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
   "SPECIFY_SEED": "指定种子",
   "SEED_INFO": "指定编号的种子在每次蒙特卡罗模拟中都将以相同的条件重现结果。",
   "SPECIFY_SEED_INFO": "启用将允许自定义“蒙特·卡洛模拟”的随机种子。",

--- a/app/locale/de.json
+++ b/app/locale/de.json
@@ -129,6 +129,7 @@
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
   "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
+  "MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -192,6 +193,7 @@
   "CROSS_CLASS_INFO": "Whether to generate a separate macro that activates the necessary cross-class actions.",
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
   "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
+  "MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",

--- a/app/locale/en.json
+++ b/app/locale/en.json
@@ -66,6 +66,7 @@
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
   "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
+  "MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -129,6 +130,7 @@
   "CROSS_CLASS_INFO": "Whether to generate a separate macro that activates the necessary cross-class actions.",
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
   "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
+  "MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",

--- a/app/locale/es.json
+++ b/app/locale/es.json
@@ -153,6 +153,7 @@
 "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
 "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
 "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
+"MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
 
 "INITIAL_GUESS": "Initial Guess",
 "WORKING_IN_PROGRESS": "Working...",
@@ -218,6 +219,7 @@
 "SPECIFY_SEED": "Specify Seed",
 "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
 "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
+"MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
 "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",
 "DEBUG": "Debug",
 "DEBUG_INFO": "Enable extra information in the simulator and solver logs.",

--- a/app/locale/fr.json
+++ b/app/locale/fr.json
@@ -127,6 +127,7 @@
   "MACRO_CROSS_ACTION_SETUP": "Macro setup des actions cross-class",
   "MACRO_INCLUDE_CLASS": "Inclure les cross-actions de la classe actuelle dans la génération",
   "MACRO_INCLUDE_LOCK": "Inclure le verrou de macro au début de chaque macro",
+  "MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
 
   "INITIAL_GUESS": "Départ renseigné",
   "WORKING_IN_PROGRESS": "Calcul en cours...",
@@ -190,6 +191,7 @@
   "CROSS_CLASS_INFO": "Indique si il faut générer une macro séparée qui active les différentes actions cross-class nécessaires.",
   "CURRENT_CLASS_INFO": "Indique si il faut inclure les actions de la classe actuelle dans la génération de la macro d'activation des actions cross-class.",
   "MACRO_LOCK_INFO": "Indique s'il faut inclure une commande de verrouillage de macro au début de chaque macro.",
+  "MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
   "SPECIFY_SEED": "Nombre spécifique",
   "SEED_INFO": "Insérer une valeur spécifique pour reproduire les conditions similaires dans les simulations Monte Carlo.",
   "SPECIFY_SEED_INFO": "Permet de modifier la valeur de base aléatoire utilisée dans les simulations Monte Carlo.",

--- a/app/locale/ja.json
+++ b/app/locale/ja.json
@@ -127,6 +127,7 @@
   "MACRO_CROSS_ACTION_SETUP": "Cross-class Action Setup Macro",
   "MACRO_INCLUDE_CLASS": "Include current class' actions in cross-class action activation macro",
   "MACRO_INCLUDE_LOCK": "Include macro lock at the start of each macro",
+  "MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
 
   "INITIAL_GUESS": "Initial Guess",
   "WORKING_IN_PROGRESS": "Working...",
@@ -190,6 +191,7 @@
   "CROSS_CLASS_INFO": "Whether to generate a separate macro that activates the necessary cross-class actions.",
   "CURRENT_CLASS_INFO": "Whether to include the current class' actions in the cross-class action activation macro.",
   "MACRO_LOCK_INFO": "Whether to include a macro lock command at the start of each macro.",
+  "MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
   "SPECIFY_SEED": "Specify Seed",
   "SEED_INFO": "Set this to a specific value to reproduce the exact same conditions in Monte Carlo simulations.",
   "SPECIFY_SEED_INFO": "Enable to override the random seed used for Monte Carlo simulations.",

--- a/app/locale/ko.json
+++ b/app/locale/ko.json
@@ -120,6 +120,7 @@
   "MACRO_CROSS_ACTION_SETUP": "보조 기술 장착 매크로",
   "MACRO_INCLUDE_CLASS": "현재 직업의 기술도 보조 기술 매크로에 포함",
   "MACRO_INCLUDE_LOCK": "매크로 첫 줄에 매크로 잠금을 포함하기",
+  "MACRO_INCLUDE_TITLE": "Include macro title at the start of each macro",
 
   "INITIAL_GUESS": "초기값",
   "WORKING_IN_PROGRESS": "조합 탐색 중...",
@@ -185,6 +186,7 @@
   "SPECIFY_SEED": "시드 설정",
   "SEED_INFO": "몬테카를로 예상치 계산 결과를 고정시킵니다.",
   "MACRO_LOCK_INFO": "매크로 첫 줄에 매크로 잠금 명령을 포함합니다.",
+  "MACRO_TITLE_INFO": "Whether to include a title at the start of each macro.",
   "SPECIFY_SEED_INFO": "몬테카를로 계산에 사용되는 시드를 설정합니다.",
   "DEBUG": "디버그",
   "DEBUG_INFO": "추가 정보를 출력합니다.",

--- a/app/modals/options.html
+++ b/app/modals/options.html
@@ -250,6 +250,10 @@
                       <input type="checkbox" name="includeMacroLock" ng-model="macroOptions.includeMacroLock"/>
                       {{ 'MACRO_INCLUDE_LOCK' | translate }}
                     </label>
+                    <label class="checkbox" tooltip="{{ 'MACRO_TITLE_INFO' | translate }}" tooltip-placement="top">
+                      <input type="checkbox" name="includeMacroTitle" ng-model="macroOptions.includeMacroTitle"/>
+                      {{ 'MACRO_INCLUDE_TITLE' | translate }}
+                    </label>
                   </div>
                 </div>
               </div>

--- a/app/views/simulator.html
+++ b/app/views/simulator.html
@@ -153,7 +153,7 @@
       </tab>
       <tab active="logTabs.macro.active">
         <tab-heading>{{ 'MACRO' | translate}}</tab-heading>
-        <macros sequence="sequence" cls="recipe.cls" options="macroOptions"></macros>
+        <macros sequence="sequence" cls="recipe.cls" options="macroOptions" recipe="recipe.name"></macros>
       </tab>
     </tabset>
   </div>

--- a/app/views/solver.html
+++ b/app/views/solver.html
@@ -114,7 +114,7 @@
             </tab>
             <tab active="logTabs.macro.active">
                 <tab-heading>{{ 'MACRO' | translate }}</tab-heading>
-                <macros sequence="pageState.solverStatus.sequence" cls="recipe.cls" options="macroOptions"></macros>
+                <macros sequence="pageState.solverStatus.sequence" cls="recipe.cls" options="macroOptions" recipe="recipe.name"></macros>
             </tab>
             <tab heading="{{ 'EXECUTION_LOG' | translate}}" active="logTabs.execution.active">
                 <pre>{{pageState.solverStatus.logs.execution}}</pre>


### PR DESCRIPTION
I have a lot of macros and often I am unsure what macro is for what. This adds
an option to add the following line to your macro:

```
/echo Macro for Larboard Hull Component started
```